### PR TITLE
fix: Additional APIs bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ venv.bak/
 
 # data
 data
+
+# sys
+.DS_Store

--- a/aser/database/kg_connection.py
+++ b/aser/database/kg_connection.py
@@ -864,7 +864,7 @@ class ASERKGConnection(object):
         )
 
     """
-    Addtional APIs
+    Additional APIs
     """
 
     def get_related_eventualities(self, eventuality):
@@ -880,7 +880,7 @@ class ASERKGConnection(object):
             return []
         if isinstance(eventuality, Eventuality):
             eid = eventuality.eid
-        if isinstance(eventuality, dict):
+        elif isinstance(eventuality, dict):
             eid = eventuality["eid"]
         elif isinstance(eventuality, str):
             eid = eventuality


### PR DESCRIPTION
Otherwise, unwanted ValueError will be raised when passing an instance of aser.eventuality.Eventuality to function `get_related_eventualities()`