### PR TITLE
[Bugfix] Set the CORENLP_HOME whether or not the port is occupied; In…

### DIFF
--- a/aser/extract/utils.py
+++ b/aser/extract/utils.py
@@ -87,9 +87,10 @@ def get_corenlp_client(corenlp_path="", corenlp_port=0, annotators=None):
     if not annotators:
         annotators = list(ANNOTATORS)
 
+    os.environ["CORENLP_HOME"] = corenlp_path
+
     if is_port_occupied(port=corenlp_port):
         try:
-            os.environ["CORENLP_HOME"] = corenlp_path
             corenlp_client = CoreNLPClient(
                 annotators=annotators,
                 timeout=99999,

--- a/aser/pipe/__init__.py
+++ b/aser/pipe/__init__.py
@@ -84,6 +84,8 @@ class ASERPipe(object):
         self.sentence_parsers = []
         self.aser_extractors = []
 
+        self.logger = init_logger(log_file=opt.log_path)
+
         for _id in range(self.n_extractors):
             corenlp_path = opt.corenlp_path
             corenlp_port = opt.base_corenlp_port + _id
@@ -104,8 +106,6 @@ class ASERPipe(object):
                 self.conceptualizer = SeedRuleASERConceptualizer()
             else:
                 raise ValueError("Error: %s = is not supported." % (opt.concept_method))
-
-        self.logger = init_logger(log_file=opt.log_path)
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
-  Set the `CORENLP_HOME` for `CoreNLPClient` whether or not the port is occupied `(asar/extract/utils.py)`
-  Init logger beforehand to avoid exceptions `(asar/pipe/__init__.py)`